### PR TITLE
Norbert/proxy

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
@@ -411,7 +411,8 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
     }
 
     public void onProximitySensorChangedState(boolean isNear) {
-        if (getReactApplicationContext().getCurrentActivity().hasWindowFocus() && automatic && getSelectedAudioDevice() == AudioDevice.EARPIECE) {
+        Activity currentActivity = getReactApplicationContext().getCurrentActivity();
+        if ((currentActivity != null && currentActivity.hasWindowFocus()) && automatic && getSelectedAudioDevice() == AudioDevice.EARPIECE) {
             if (isNear) {
                 turnScreenOff();
             } else {

--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
@@ -411,7 +411,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
     }
 
     public void onProximitySensorChangedState(boolean isNear) {
-        if (automatic && getSelectedAudioDevice() == AudioDevice.EARPIECE) {
+        if (getReactApplicationContext().getCurrentActivity().hasWindowFocus() && automatic && getSelectedAudioDevice() == AudioDevice.EARPIECE) {
             if (isNear) {
                 turnScreenOff();
             } else {


### PR DESCRIPTION
on android, when in call and on earpiece the proximity sensor is handling events events when app is in background, which means that it turns the screen off, which is not desirable ... fixing with patch