### PR TITLE
Do not reset Speaker selection on stop/start

### DIFF
--- a/ios/RNInCallManager/RNInCallManager.m
+++ b/ios/RNInCallManager/RNInCallManager.m
@@ -149,7 +149,6 @@ RCT_EXPORT_METHOD(start:(NSString *)mediaType
     }
     NSLog(@"RNInCallManager.start() start InCallManager. media=%@, type=%@, mode=%@", _media, _media, _incallAudioMode);
     [self storeOriginalAudioSetup];
-    _forceSpeakerOn = 0;
     [self startAudioSessionNotification];
     [self audioSessionSetCategory:_incallAudioCategory
                           options:0
@@ -195,7 +194,6 @@ RCT_EXPORT_METHOD(stop:(NSString *)busytoneUriType)
         [self setKeepScreenOn:NO];
         [self stopAudioSessionNotification];
         [[NSNotificationCenter defaultCenter] removeObserver:self];
-        _forceSpeakerOn = 0;
         _audioSessionInitialized = NO;
     }
 }


### PR DESCRIPTION
While debugging https://linear.app/aroundco/issue/FRN-3251/[stage][mobile]audio-output-changes-when-network-connection-is-dropped and https://linear.app/aroundco/issue/FRN-4243/[iosmobile]-audio-output-randomly-switches-from-earphone-to-speaker I've found that when we lost connection with the server we call https://github.com/TeamAround/Around/blob/394e99c968efe3f8c6bda29150f80d84367c8bc0/mobileapp/meetClientMobileDevice.ts#L184 which is not only stopping InCallManager but also turns out to reset `forceSpeakerOn` flag https://github.com/TeamAround/react-native-incall-manager/blob/88b6a99fe0c972a1a58235dce2d211d877156fa2/ios/RNInCallManager/RNInCallManager.m#L198

The same happens when we connect back to the room and call `IncallManager.start()` - https://github.com/TeamAround/react-native-incall-manager/blob/88b6a99fe0c972a1a58235dce2d211d877156fa2/ios/RNInCallManager/RNInCallManager.m#L152

After looking into the code it seems to be safe to simply remove resetting this flag from those 2 methods as `forceSpeakerOn` is reset anyway while initializing a new `IncallManager` instance and every single time when we join room for the first time: https://github.com/TeamAround/Around/blob/394e99c968efe3f8c6bda29150f80d84367c8bc0/mobileapp/meetClientMobileDevice.ts#L565

So I assume this change will only affect reconnecting while staying all the time in the same room. I tested it and looks like it's working as expected. However, I might be not aware of something so please take a look and let me know if I missed anything. Thank you in advance.