### PR TITLE
Upstream BT changes + fix audio outputs list updates

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCBluetoothManager.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCBluetoothManager.java
@@ -7,9 +7,7 @@
  *  in the file PATENTS.  All contributing project authors may
  *  be found in the AUTHORS file in the root of the source tree.
  */
-
 package com.zxcpoiu.incallmanager.AppRTC;
-
 import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
@@ -21,27 +19,27 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Process;
 import android.util.Log;
+import androidx.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
-
+import com.zxcpoiu.incallmanager.AppRTC.AppRTCUtils;
+import com.zxcpoiu.incallmanager.AppRTC.ThreadUtils;
 import com.zxcpoiu.incallmanager.InCallManagerModule;
-
 /**
  * AppRTCProximitySensor manages functions related to Bluetoth devices in the
  * AppRTC demo.
  */
 public class AppRTCBluetoothManager {
   private static final String TAG = "AppRTCBluetoothManager";
-
   // Timeout interval for starting or stopping audio to a Bluetooth SCO device.
   private static final int BLUETOOTH_SCO_TIMEOUT_MS = 4000;
   // Maximum number of SCO connection attempts.
   private static final int MAX_SCO_CONNECTION_ATTEMPTS = 2;
-
   // Bluetooth connection state.
   public enum State {
     // Bluetooth is not available; no adapter or Bluetooth is off.
@@ -61,20 +59,21 @@ public class AppRTCBluetoothManager {
     // Bluetooth audio SCO connection with remote device is established.
     SCO_CONNECTED
   }
-
   private final Context apprtcContext;
   private final InCallManagerModule apprtcAudioManager;
+  @Nullable
   private final AudioManager audioManager;
   private final Handler handler;
-
   int scoConnectionAttempts;
   private State bluetoothState;
   private final BluetoothProfile.ServiceListener bluetoothServiceListener;
+  @Nullable
   private BluetoothAdapter bluetoothAdapter;
+  @Nullable
   private BluetoothHeadset bluetoothHeadset;
+  @Nullable
   private BluetoothDevice bluetoothDevice;
   private final BroadcastReceiver bluetoothHeadsetReceiver;
-
   // Runs when the Bluetooth timeout expires. We use that timeout after calling
   // startScoAudio() or stopScoAudio() because we're not guaranteed to get a
   // callback after those calls.
@@ -84,7 +83,6 @@ public class AppRTCBluetoothManager {
       bluetoothTimeout();
     }
   };
-
   /**
    * Implementation of an interface that notifies BluetoothProfile IPC clients when they have been
    * connected to or disconnected from the service.
@@ -104,7 +102,6 @@ public class AppRTCBluetoothManager {
       updateAudioDeviceState();
       Log.d(TAG, "onServiceConnected done: BT state=" + bluetoothState);
     }
-
     @Override
     /** Notifies the client when the proxy object has been disconnected from the service. */
     public void onServiceDisconnected(int profile) {
@@ -120,7 +117,6 @@ public class AppRTCBluetoothManager {
       Log.d(TAG, "onServiceDisconnected done: BT state=" + bluetoothState);
     }
   }
-
   // Intent broadcast receiver which handles changes in Bluetooth device availability.
   // Detects headset changes and Bluetooth SCO state changes.
   private class BluetoothHeadsetBroadcastReceiver extends BroadcastReceiver {
@@ -136,7 +132,7 @@ public class AppRTCBluetoothManager {
       // headset while audio is active using another audio device.
       if (action.equals(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED)) {
         final int state =
-            intent.getIntExtra(BluetoothHeadset.EXTRA_STATE, BluetoothHeadset.STATE_DISCONNECTED);
+                intent.getIntExtra(BluetoothHeadset.EXTRA_STATE, BluetoothHeadset.STATE_DISCONNECTED);
         Log.d(TAG, "BluetoothHeadsetBroadcastReceiver.onReceive: "
                 + "a=ACTION_CONNECTION_STATE_CHANGED, "
                 + "s=" + stateToString(state) + ", "
@@ -158,7 +154,7 @@ public class AppRTCBluetoothManager {
         // Typically received after call to startScoAudio() has finalized.
       } else if (action.equals(BluetoothHeadset.ACTION_AUDIO_STATE_CHANGED)) {
         final int state = intent.getIntExtra(
-            BluetoothHeadset.EXTRA_STATE, BluetoothHeadset.STATE_AUDIO_DISCONNECTED);
+                BluetoothHeadset.EXTRA_STATE, BluetoothHeadset.STATE_AUDIO_DISCONNECTED);
         Log.d(TAG, "BluetoothHeadsetBroadcastReceiver.onReceive: "
                 + "a=ACTION_AUDIO_STATE_CHANGED, "
                 + "s=" + stateToString(state) + ", "
@@ -188,15 +184,14 @@ public class AppRTCBluetoothManager {
       Log.d(TAG, "onReceive done: BT state=" + bluetoothState);
     }
   }
-
   /** Construction. */
   public static AppRTCBluetoothManager create(Context context, InCallManagerModule audioManager) {
-    Log.d(TAG, "create");
+    Log.d(TAG, "create" + AppRTCUtils.getThreadInfo());
     return new AppRTCBluetoothManager(context, audioManager);
   }
-
   protected AppRTCBluetoothManager(Context context, InCallManagerModule audioManager) {
     Log.d(TAG, "ctor");
+    ThreadUtils.checkIsOnMainThread();
     apprtcContext = context;
     apprtcAudioManager = audioManager;
     this.audioManager = getAudioManager(context);
@@ -205,12 +200,11 @@ public class AppRTCBluetoothManager {
     bluetoothHeadsetReceiver = new BluetoothHeadsetBroadcastReceiver();
     handler = new Handler(Looper.getMainLooper());
   }
-
   /** Returns the internal state. */
   public State getState() {
+    ThreadUtils.checkIsOnMainThread();
     return bluetoothState;
   }
-
   /**
    * Activates components required to detect Bluetooth devices and to enable
    * BT SCO (audio is routed via BT SCO) for the headset profile. The end
@@ -225,8 +219,10 @@ public class AppRTCBluetoothManager {
    * change.
    */
   public void start() {
+    ThreadUtils.checkIsOnMainThread();
     Log.d(TAG, "start");
-    if (!hasPermission(apprtcContext, android.Manifest.permission.BLUETOOTH)) {
+    String p = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? android.Manifest.permission.BLUETOOTH_CONNECT : android.Manifest.permission.BLUETOOTH;
+    if (!hasPermission(apprtcContext, p)) {
       Log.w(TAG, "Process (pid=" + Process.myPid() + ") lacks BLUETOOTH permission");
       return;
     }
@@ -269,9 +265,9 @@ public class AppRTCBluetoothManager {
     bluetoothState = State.HEADSET_UNAVAILABLE;
     Log.d(TAG, "start done: BT state=" + bluetoothState);
   }
-
   /** Stops and closes all components related to Bluetooth audio. */
   public void stop() {
+    ThreadUtils.checkIsOnMainThread();
     Log.d(TAG, "stop: BT state=" + bluetoothState);
     if (bluetoothAdapter == null) {
       return;
@@ -293,7 +289,6 @@ public class AppRTCBluetoothManager {
     bluetoothState = State.UNINITIALIZED;
     Log.d(TAG, "stop done: BT state=" + bluetoothState);
   }
-
   /**
    * Starts Bluetooth SCO connection with remote device.
    * Note that the phone application always has the priority on the usage of the SCO connection
@@ -308,6 +303,7 @@ public class AppRTCBluetoothManager {
    * accept SCO audio without a "call".
    */
   public boolean startScoAudio() {
+    ThreadUtils.checkIsOnMainThread();
     Log.d(TAG, "startSco: BT state=" + bluetoothState + ", "
             + "attempts: " + scoConnectionAttempts + ", "
             + "SCO is on: " + isScoOn());
@@ -333,9 +329,9 @@ public class AppRTCBluetoothManager {
             + "SCO is on: " + isScoOn());
     return true;
   }
-
   /** Stops Bluetooth SCO connection with remote device. */
   public void stopScoAudio() {
+    ThreadUtils.checkIsOnMainThread();
     Log.d(TAG, "stopScoAudio: BT state=" + bluetoothState + ", "
             + "SCO is on: " + isScoOn());
     if (bluetoothState != State.SCO_CONNECTING && bluetoothState != State.SCO_CONNECTED) {
@@ -348,12 +344,11 @@ public class AppRTCBluetoothManager {
     Log.d(TAG, "stopScoAudio done: BT state=" + bluetoothState + ", "
             + "SCO is on: " + isScoOn());
   }
-
   /**
    * Use the BluetoothHeadset proxy object (controls the Bluetooth Headset
    * Service via IPC) to update the list of connected devices for the HEADSET
    * profile. The internal state will change to HEADSET_UNAVAILABLE or to
-   * HEADSET_AVAILABLE and |bluetoothDevice| will be mapped to the connected
+   * HEADSET_AVAILABLE and `bluetoothDevice` will be mapped to the connected
    * device if available.
    */
   public void updateDevice() {
@@ -387,7 +382,6 @@ public class AppRTCBluetoothManager {
     if (devices.isEmpty()) {
       return "";
     }
-
     // Always use first device in list.
     BluetoothDevice bluetoothDevice = devices.get(0);
     String name = bluetoothDevice.getName();
@@ -397,28 +391,24 @@ public class AppRTCBluetoothManager {
   /**
    * Stubs for test mocks.
    */
+  @Nullable
   protected AudioManager getAudioManager(Context context) {
     return (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
   }
-
   protected void registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
     apprtcContext.registerReceiver(receiver, filter);
   }
-
   protected void unregisterReceiver(BroadcastReceiver receiver) {
     apprtcContext.unregisterReceiver(receiver);
   }
-
   protected boolean getBluetoothProfileProxy(
-      Context context, BluetoothProfile.ServiceListener listener, int profile) {
+          Context context, BluetoothProfile.ServiceListener listener, int profile) {
     return bluetoothAdapter.getProfileProxy(context, listener, profile);
   }
-
   protected boolean hasPermission(Context context, String permission) {
     return apprtcContext.checkPermission(permission, Process.myPid(), Process.myUid())
-        == PackageManager.PERMISSION_GRANTED;
+            == PackageManager.PERMISSION_GRANTED;
   }
-
   /** Logs the state of the local Bluetooth adapter. */
   @SuppressLint("HardwareIds")
   protected void logBluetoothAdapterInfo(BluetoothAdapter localAdapter) {
@@ -436,30 +426,30 @@ public class AppRTCBluetoothManager {
       }
     }
   }
-
   /** Ensures that the audio manager updates its list of available audio devices. */
   private void updateAudioDeviceState() {
+    ThreadUtils.checkIsOnMainThread();
     Log.d(TAG, "updateAudioDeviceState");
     apprtcAudioManager.updateAudioDeviceState();
   }
-
   /** Starts timer which times out after BLUETOOTH_SCO_TIMEOUT_MS milliseconds. */
   private void startTimer() {
+    ThreadUtils.checkIsOnMainThread();
     Log.d(TAG, "startTimer");
     handler.postDelayed(bluetoothTimeoutRunnable, BLUETOOTH_SCO_TIMEOUT_MS);
   }
-
   /** Cancels any outstanding timer tasks. */
   private void cancelTimer() {
+    ThreadUtils.checkIsOnMainThread();
     Log.d(TAG, "cancelTimer");
     handler.removeCallbacks(bluetoothTimeoutRunnable);
   }
-
   /**
    * Called when start of the BT SCO channel takes too long time. Usually
    * happens when the BT device has been turned on during an ongoing call.
    */
   private void bluetoothTimeout() {
+    ThreadUtils.checkIsOnMainThread();
     if (bluetoothState == State.UNINITIALIZED || bluetoothHeadset == null) {
       return;
     }
@@ -493,12 +483,10 @@ public class AppRTCBluetoothManager {
     updateAudioDeviceState();
     Log.d(TAG, "bluetoothTimeout done: BT state=" + bluetoothState);
   }
-
   /** Checks whether audio uses Bluetooth SCO. */
   private boolean isScoOn() {
     return audioManager.isBluetoothScoOn();
   }
-
   /** Converts BluetoothAdapter states into local string representations. */
   private String stateToString(int state) {
     switch (state) {

--- a/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCProximitySensor.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCProximitySensor.java
@@ -7,9 +7,7 @@
  *  in the file PATENTS.  All contributing project authors may
  *  be found in the AUTHORS file in the root of the source tree.
  */
-
 package com.zxcpoiu.incallmanager.AppRTC;
-
 import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
@@ -17,7 +15,9 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.os.Build;
 import android.util.Log;
-
+import androidx.annotation.Nullable;
+import com.zxcpoiu.incallmanager.AppRTC.AppRTCUtils;
+import com.zxcpoiu.incallmanager.AppRTC.ThreadUtils;
 /**
  * AppRTCProximitySensor manages functions related to the proximity sensor in
  * the AppRTC demo.
@@ -29,33 +29,30 @@ import android.util.Log;
  */
 public class AppRTCProximitySensor implements SensorEventListener {
   private static final String TAG = "AppRTCProximitySensor";
-
   // This class should be created, started and stopped on one thread
-  // (e.g. the main thread). We use |nonThreadSafe| to ensure that this is
-  // the case. Only active when |DEBUG| is set to true.
-
+  // (e.g. the main thread). We use `nonThreadSafe` to ensure that this is
+  // the case. Only active when `DEBUG` is set to true.
+  private final ThreadUtils.ThreadChecker threadChecker = new ThreadUtils.ThreadChecker();
   private final Runnable onSensorStateListener;
   private final SensorManager sensorManager;
-  private Sensor proximitySensor = null;
-  private boolean lastStateReportIsNear = false;
-
+  @Nullable private Sensor proximitySensor;
+  private boolean lastStateReportIsNear;
   /** Construction */
   public static AppRTCProximitySensor create(Context context, Runnable sensorStateListener) {
     return new AppRTCProximitySensor(context, sensorStateListener);
   }
-
   private AppRTCProximitySensor(Context context, Runnable sensorStateListener) {
-    Log.d(TAG, "AppRTCProximitySensor");
+    Log.d(TAG, "AppRTCProximitySensor" + AppRTCUtils.getThreadInfo());
     onSensorStateListener = sensorStateListener;
     sensorManager = ((SensorManager) context.getSystemService(Context.SENSOR_SERVICE));
   }
-
   /**
    * Activate the proximity sensor. Also do initialization if called for the
    * first time.
    */
   public boolean start() {
-    Log.d(TAG, "start");
+    threadChecker.checkIsOnValidThread();
+    Log.d(TAG, "start" + AppRTCUtils.getThreadInfo());
     if (!initDefaultSensor()) {
       // Proximity sensor is not supported on this device.
       return false;
@@ -63,30 +60,32 @@ public class AppRTCProximitySensor implements SensorEventListener {
     sensorManager.registerListener(this, proximitySensor, SensorManager.SENSOR_DELAY_NORMAL);
     return true;
   }
-
   /** Deactivate the proximity sensor. */
   public void stop() {
-    Log.d(TAG, "stop");
+    threadChecker.checkIsOnValidThread();
+    Log.d(TAG, "stop" + AppRTCUtils.getThreadInfo());
     if (proximitySensor == null) {
       return;
     }
     sensorManager.unregisterListener(this, proximitySensor);
   }
-
   /** Getter for last reported state. Set to true if "near" is reported. */
   public boolean sensorReportsNearState() {
+    threadChecker.checkIsOnValidThread();
     return lastStateReportIsNear;
   }
-
   @Override
   public final void onAccuracyChanged(Sensor sensor, int accuracy) {
+    threadChecker.checkIsOnValidThread();
+    AppRTCUtils.assertIsTrue(sensor.getType() == Sensor.TYPE_PROXIMITY);
     if (accuracy == SensorManager.SENSOR_STATUS_UNRELIABLE) {
       Log.e(TAG, "The values returned by this sensor cannot be trusted");
     }
   }
-
   @Override
   public final void onSensorChanged(SensorEvent event) {
+    threadChecker.checkIsOnValidThread();
+    AppRTCUtils.assertIsTrue(event.sensor.getType() == Sensor.TYPE_PROXIMITY);
     // As a best practice; do as little as possible within this method and
     // avoid blocking.
     float distanceInCentimeters = event.values[0];
@@ -97,18 +96,15 @@ public class AppRTCProximitySensor implements SensorEventListener {
       Log.d(TAG, "Proximity sensor => FAR state");
       lastStateReportIsNear = false;
     }
-
     // Report about new state to listening client. Client can then call
     // sensorReportsNearState() to query the current state (NEAR or FAR).
     if (onSensorStateListener != null) {
       onSensorStateListener.run();
     }
-
-    Log.d(TAG, "onSensorChanged" + ": "
+    Log.d(TAG, "onSensorChanged" + AppRTCUtils.getThreadInfo() + ": "
             + "accuracy=" + event.accuracy + ", timestamp=" + event.timestamp + ", distance="
             + event.values[0]);
   }
-
   /**
    * Get default proximity sensor if it exists. Tablet devices (e.g. Nexus 7)
    * does not support this type of sensor and false will be returned in such
@@ -125,7 +121,6 @@ public class AppRTCProximitySensor implements SensorEventListener {
     logProximitySensorInfo();
     return true;
   }
-
   /** Helper method for logging information about the proximity sensor. */
   private void logProximitySensorInfo() {
     if (proximitySensor == null) {
@@ -138,16 +133,10 @@ public class AppRTCProximitySensor implements SensorEventListener {
     info.append(", resolution: ").append(proximitySensor.getResolution());
     info.append(", max range: ").append(proximitySensor.getMaximumRange());
     info.append(", min delay: ").append(proximitySensor.getMinDelay());
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
-      // Added in API level 20.
-      info.append(", type: ").append(proximitySensor.getStringType());
-    }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      // Added in API level 21.
-      info.append(", max delay: ").append(proximitySensor.getMaxDelay());
-      info.append(", reporting mode: ").append(proximitySensor.getReportingMode());
-      info.append(", isWakeUpSensor: ").append(proximitySensor.isWakeUpSensor());
-    }
+    info.append(", type: ").append(proximitySensor.getStringType());
+    info.append(", max delay: ").append(proximitySensor.getMaxDelay());
+    info.append(", reporting mode: ").append(proximitySensor.getReportingMode());
+    info.append(", isWakeUpSensor: ").append(proximitySensor.isWakeUpSensor());
     Log.d(TAG, info.toString());
   }
 }

--- a/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCUtils.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCUtils.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2014 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+package com.zxcpoiu.incallmanager.AppRTC;
+import android.os.Build;
+import android.util.Log;
+/**
+ * AppRTCUtils provides helper functions for managing thread safety.
+ */
+public final class AppRTCUtils {
+    private AppRTCUtils() {}
+    /** Helper method which throws an exception  when an assertion has failed. */
+    public static void assertIsTrue(boolean condition) {
+        if (!condition) {
+            throw new AssertionError("Expected condition to be true");
+        }
+    }
+    /** Helper method for building a string of thread information.*/
+    public static String getThreadInfo() {
+        return "@[name=" + Thread.currentThread().getName() + ", id=" + Thread.currentThread().getId()
+                + "]";
+    }
+    /** Information about the current build, taken from system properties. */
+    public static void logDeviceInfo(String tag) {
+        Log.d(tag, "Android SDK: " + Build.VERSION.SDK_INT + ", "
+                + "Release: " + Build.VERSION.RELEASE + ", "
+                + "Brand: " + Build.BRAND + ", "
+                + "Device: " + Build.DEVICE + ", "
+                + "Id: " + Build.ID + ", "
+                + "Hardware: " + Build.HARDWARE + ", "
+                + "Manufacturer: " + Build.MANUFACTURER + ", "
+                + "Model: " + Build.MODEL + ", "
+                + "Product: " + Build.PRODUCT);
+    }
+}

--- a/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/ThreadUtils.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/ThreadUtils.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+package com.zxcpoiu.incallmanager.AppRTC;
+import android.os.Looper;
+import androidx.annotation.Nullable;
+public class ThreadUtils {
+    /**
+     * Utility class to be used for checking that a method is called on the correct thread.
+     */
+    public static class ThreadChecker {
+        @Nullable private Thread thread = Thread.currentThread();
+        public void checkIsOnValidThread() {
+            if (thread == null) {
+                thread = Thread.currentThread();
+            }
+            if (Thread.currentThread() != thread) {
+                throw new IllegalStateException("Wrong thread");
+            }
+        }
+        public void detachThread() {
+            thread = null;
+        }
+    }
+    /**
+     * Throws exception if called from other than main thread.
+     */
+    public static void checkIsOnMainThread() {
+        if (Thread.currentThread() != Looper.getMainLooper().getThread()) {
+            throw new IllegalStateException("Not on main thread!");
+        }
+    }
+}

--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
@@ -161,7 +161,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
     private final String useSpeakerphone = SPEAKERPHONE_AUTO;
 
     // Handles all tasks related to Bluetooth headset devices.
-    private AppRTCBluetoothManager bluetoothManager;
+    private AppRTCBluetoothManager bluetoothManager = null;
 
     private final InCallProximityManager proximityManager;
 
@@ -206,8 +206,8 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
         mRequestPermissionCodePromises = new SparseArray<Promise>();
         mRequestPermissionCodeTargetPermission = new SparseArray<String>();
         mOnFocusChangeListener = new OnFocusChangeListener();
-        proximityManager = InCallProximityManager.create(reactContext, this);
         wakeLockUtils = new InCallWakeLockUtils(reactContext);
+        proximityManager = InCallProximityManager.create(reactContext, this);
 
         Log.d(TAG, "InCallManager initialized");
     }
@@ -603,8 +603,10 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             startEvents();
 
             if (isAndroidBluetoothPermissionGranted()) {
-                bluetoothManager = AppRTCBluetoothManager.create(reactContext, this);
-                bluetoothManager.start();
+                UiThreadUtil.runOnUiThread(() -> {
+                    bluetoothManager = AppRTCBluetoothManager.create(reactContext, this);
+                    bluetoothManager.start();
+                });
             }
 
             // TODO: even if not acquired focus, we can still play sounds. but need figure out which is better.
@@ -646,7 +648,9 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
                 setMicrophoneMute(false);
                 forceSpeakerOn = 0;
                 if (isAndroidBluetoothPermissionGrantedAndBluetoothManagerExists()) {
-                    bluetoothManager.stop();
+                    UiThreadUtil.runOnUiThread(() -> {
+                        bluetoothManager.stop();
+                    });
                 }
                 restoreOriginalAudioSetup();
                 releaseAudioFocus();
@@ -1821,105 +1825,107 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
      * Updates list of possible audio devices and make new device selection.
      */
     public void updateAudioDeviceState() {
-        Log.d(TAG, "--- updateAudioDeviceState: "
-                + "wired headset=" + hasWiredHeadset + ", "
-                + "BT state=" + (isAndroidBluetoothPermissionGrantedAndBluetoothManagerExists() ? bluetoothManager.getState() : "disabled"));
-        Log.d(TAG, "Device status: "
-                + "available=" + audioDevices + ", "
-                + "selected=" + selectedAudioDevice + ", "
-                + "user selected=" + userSelectedAudioDevice);
-
-        // Check if any Bluetooth headset is connected. The internal BT state will
-        // change accordingly.
-        // TODO(henrika): perhaps wrap required state into BT manager.
-        if (isAndroidBluetoothPermissionGrantedAndBluetoothManagerExists() && (bluetoothManager.getState() == AppRTCBluetoothManager.State.HEADSET_AVAILABLE
-                || bluetoothManager.getState() == AppRTCBluetoothManager.State.HEADSET_UNAVAILABLE
-                || bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_DISCONNECTING)) {
-            bluetoothManager.updateDevice();
-        }
-
-        // Update the set of available audio devices.
-        Set<AudioDevice> newAudioDevices = new HashSet<>();
-
-        // always assume device has speaker phone
-        newAudioDevices.add(AudioDevice.SPEAKER_PHONE);
-
-        if (isAndroidBluetoothPermissionGrantedAndBluetoothManagerExists() && (bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_CONNECTED
-                || bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_CONNECTING
-                || bluetoothManager.getState() == AppRTCBluetoothManager.State.HEADSET_AVAILABLE)) {
-            newAudioDevices.add(AudioDevice.BLUETOOTH);
-        }
-
-        if (hasWiredHeadset) {
-            newAudioDevices.add(AudioDevice.WIRED_HEADSET);
-        }
-
-        if (hasEarpiece()) {
-            newAudioDevices.add(AudioDevice.EARPIECE);
-        }
-
-        // --- check whether user selected audio device is available
-        if (userSelectedAudioDevice != null
-                && userSelectedAudioDevice != AudioDevice.NONE
-                && !newAudioDevices.contains(userSelectedAudioDevice)) {
-            userSelectedAudioDevice = AudioDevice.NONE;
-        }
-
-        // Store state which is set to true if the device list has changed.
-        boolean audioDeviceSetUpdated = !audioDevices.equals(newAudioDevices);
-        // Update the existing audio device set.
-        audioDevices = newAudioDevices;
-
-        AudioDevice newAudioDevice = getPreferredAudioDevice();
-
-        // --- stop bluetooth if needed
-        if (isAndroidBluetoothPermissionGrantedAndBluetoothManagerExists() && (selectedAudioDevice == AudioDevice.BLUETOOTH
-                && newAudioDevice != AudioDevice.BLUETOOTH
-                && (bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_CONNECTED
-                || bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_CONNECTING))
-        ) {
-            bluetoothManager.stopScoAudio();
-            bluetoothManager.updateDevice();
-        }
-
-        // --- start bluetooth if needed
-        if (isAndroidBluetoothPermissionGrantedAndBluetoothManagerExists() && (selectedAudioDevice != AudioDevice.BLUETOOTH
-                && newAudioDevice == AudioDevice.BLUETOOTH
-                && bluetoothManager.getState() == AppRTCBluetoothManager.State.HEADSET_AVAILABLE)) {
-            // Attempt to start Bluetooth SCO audio (takes a few second to start).
-            if (!bluetoothManager.startScoAudio()) {
-                // Remove BLUETOOTH from list of available devices since SCO failed.
-                audioDevices.remove(AudioDevice.BLUETOOTH);
-                audioDeviceSetUpdated = true;
-                if (userSelectedAudioDevice == AudioDevice.BLUETOOTH) {
-                    userSelectedAudioDevice = AudioDevice.NONE;
-                }
-                newAudioDevice = getPreferredAudioDevice();
-            }
-        }
-
-        if (isAndroidBluetoothPermissionGrantedAndBluetoothManagerExists() && (newAudioDevice == AudioDevice.BLUETOOTH
-                && bluetoothManager.getState() != AppRTCBluetoothManager.State.SCO_CONNECTED)) {
-            newAudioDevice = getPreferredAudioDevice(true); // --- skip bluetooth
-        }
-
-        // Switch to new device but only if there has been any changes.
-        if (newAudioDevice != selectedAudioDevice || audioDeviceSetUpdated) {
-
-            // Do the required device switch.
-            setAudioDeviceInternal(newAudioDevice);
-            Log.d(TAG, "New device status: "
+        UiThreadUtil.runOnUiThread(() -> {
+            Log.d(TAG, "--- updateAudioDeviceState: "
+                    + "wired headset=" + hasWiredHeadset + ", "
+                    + "BT state=" + bluetoothManager.getState());
+            Log.d(TAG, "Device status: "
                     + "available=" + audioDevices + ", "
-                    + "selected=" + newAudioDevice);
-            /*
-            if (audioManagerEvents != null) {
-                // Notify a listening client that audio device has been changed.
-                audioManagerEvents.onAudioDeviceChanged(selectedAudioDevice, audioDevices);
+                    + "selected=" + selectedAudioDevice + ", "
+                    + "user selected=" + userSelectedAudioDevice);
+
+            // Check if any Bluetooth headset is connected. The internal BT state will
+            // change accordingly.
+            // TODO(henrika): perhaps wrap required state into BT manager.
+            if (bluetoothManager.getState() == AppRTCBluetoothManager.State.HEADSET_AVAILABLE
+                    || bluetoothManager.getState() == AppRTCBluetoothManager.State.HEADSET_UNAVAILABLE
+                    || bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_DISCONNECTING) {
+                bluetoothManager.updateDevice();
             }
-            */
-            sendEvent("onAudioDeviceChanged", getAudioDeviceStatusMap());
-        }
-        Log.d(TAG, "--- updateAudioDeviceState done");
+
+            // Update the set of available audio devices.
+            Set<AudioDevice> newAudioDevices = new HashSet<>();
+
+            // always assume device has speaker phone
+            newAudioDevices.add(AudioDevice.SPEAKER_PHONE);
+
+            if (bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_CONNECTED
+                    || bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_CONNECTING
+                    || bluetoothManager.getState() == AppRTCBluetoothManager.State.HEADSET_AVAILABLE) {
+                newAudioDevices.add(AudioDevice.BLUETOOTH);
+            }
+
+            if (hasWiredHeadset) {
+                newAudioDevices.add(AudioDevice.WIRED_HEADSET);
+            }
+
+            if (hasEarpiece()) {
+                newAudioDevices.add(AudioDevice.EARPIECE);
+            }
+
+            // --- check whether user selected audio device is available
+            if (userSelectedAudioDevice != null
+                    && userSelectedAudioDevice != AudioDevice.NONE
+                    && !newAudioDevices.contains(userSelectedAudioDevice)) {
+                userSelectedAudioDevice = AudioDevice.NONE;
+            }
+
+            // Store state which is set to true if the device list has changed.
+            boolean audioDeviceSetUpdated = !audioDevices.equals(newAudioDevices);
+            // Update the existing audio device set.
+            audioDevices = newAudioDevices;
+
+            AudioDevice newAudioDevice = getPreferredAudioDevice();
+
+            // --- stop bluetooth if needed
+            if (selectedAudioDevice == AudioDevice.BLUETOOTH
+                    && newAudioDevice != AudioDevice.BLUETOOTH
+                    && (bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_CONNECTED
+                    || bluetoothManager.getState() == AppRTCBluetoothManager.State.SCO_CONNECTING)
+            ) {
+                bluetoothManager.stopScoAudio();
+                bluetoothManager.updateDevice();
+            }
+
+            // --- start bluetooth if needed
+            if (selectedAudioDevice != AudioDevice.BLUETOOTH
+                    && newAudioDevice == AudioDevice.BLUETOOTH
+                    && bluetoothManager.getState() == AppRTCBluetoothManager.State.HEADSET_AVAILABLE) {
+                // Attempt to start Bluetooth SCO audio (takes a few second to start).
+                if (!bluetoothManager.startScoAudio()) {
+                    // Remove BLUETOOTH from list of available devices since SCO failed.
+                    audioDevices.remove(AudioDevice.BLUETOOTH);
+                    audioDeviceSetUpdated = true;
+                    if (userSelectedAudioDevice == AudioDevice.BLUETOOTH) {
+                        userSelectedAudioDevice = AudioDevice.NONE;
+                    }
+                    newAudioDevice = getPreferredAudioDevice();
+                }
+            }
+
+            if (newAudioDevice == AudioDevice.BLUETOOTH
+                    && bluetoothManager.getState() != AppRTCBluetoothManager.State.SCO_CONNECTED) {
+                newAudioDevice = getPreferredAudioDevice(true); // --- skip bluetooth
+            }
+
+            // Switch to new device but only if there has been any changes.
+            if (newAudioDevice != selectedAudioDevice || audioDeviceSetUpdated) {
+
+                // Do the required device switch.
+                setAudioDeviceInternal(newAudioDevice);
+                Log.d(TAG, "New device status: "
+                        + "available=" + audioDevices + ", "
+                        + "selected=" + newAudioDevice);
+                /*
+                if (audioManagerEvents != null) {
+                    // Notify a listening client that audio device has been changed.
+                    audioManagerEvents.onAudioDeviceChanged(selectedAudioDevice, audioDevices);
+                }
+                */
+                sendEvent("onAudioDeviceChanged", getAudioDeviceStatusMap());
+            }
+            Log.d(TAG, "--- updateAudioDeviceState done");
+        });
     }
 
     private WritableMap getAudioDeviceStatusMap() {

--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallProximityManager.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallProximityManager.java
@@ -27,6 +27,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.Runnable;
 
+import com.facebook.react.bridge.UiThreadUtil;
+
 import com.zxcpoiu.incallmanager.AppRTC.AppRTCProximitySensor;
 
 public class InCallProximityManager {
@@ -46,14 +48,11 @@ public class InCallProximityManager {
         Log.d(TAG, "InCallProximityManager");
         checkProximitySupport(context);
         if (proximitySupported) {
-            proximitySensor = AppRTCProximitySensor.create(context,
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        inCallManager.onProximitySensorChangedState(proximitySensor.sensorReportsNearState());               
-                    }
-                }
-            );
+            UiThreadUtil.runOnUiThread(() -> {
+                proximitySensor = AppRTCProximitySensor.create(context, () -> {
+                    inCallManager.onProximitySensorChangedState(proximitySensor.sensorReportsNearState());
+                });
+            });
         }
     }
 
@@ -108,11 +107,16 @@ public class InCallProximityManager {
         if (!proximitySupported) {
             return false;
         }
-        return proximitySensor.start();
+        UiThreadUtil.runOnUiThread(() -> {
+            proximitySensor.start();
+        });
+        return true;
     }
 
     public void stop() {
-        proximitySensor.stop();
+        UiThreadUtil.runOnUiThread(() -> {
+            proximitySensor.stop();
+        });
     }
 
     public boolean isProximitySupported() {


### PR DESCRIPTION
Upstream contains changes made only for Android in this specific commit from the original repo: https://github.com/react-native-webrtc/react-native-incall-manager/commit/ffdb9b3f6f677a6b4fd76256d3200e5ad99a95d1

Without this change, Android was not detecting new BT headphones connected to the phone, and as a result, was not updating the list of available audio outputs.