### PR TITLE
fix: use ReactNative's PermissionModule instead of the Android permission API directly, so that concurrent permission requests don't crash

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerPackage.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerPackage.java
@@ -41,8 +41,4 @@ public class InCallManagerPackage implements ReactPackage {
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
-
-    public static void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        InCallManagerModule.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
 }


### PR DESCRIPTION
ReactNative native modules must not use the Android permission APIs directly. All permission requests must go through ReactNative's `PermissionModule`. Otherwise `PermissionModule` will crash when it encounters unknown request IDs coming from the activity-global result handler.